### PR TITLE
plat: rcar: rework board id detection

### DIFF
--- a/plat/renesas/rcar/bl2_rcar_setup.c
+++ b/plat/renesas/rcar/bl2_rcar_setup.c
@@ -341,8 +341,6 @@ void bl2_early_platform_setup(meminfo_t *mem_layout)
 	uint32_t modemr;
 	uint32_t modemr_boot_dev;
 	int32_t ret;
-	uint32_t board_type;
-	uint32_t board_rev;
 	uint32_t prr_val;
 	char msg[128];
 	const char *str;
@@ -439,24 +437,12 @@ void bl2_early_platform_setup(meminfo_t *mem_layout)
 		 + RCAR_MAJOR_OFFSET, (prr_val & RCAR_MINOR_MASK));
 	NOTICE("%s", msg);
 
-	/* Board ID detection */
-	(void)get_board_type(&board_type, &board_rev);
-	
-	switch (board_type) {
-	case BOARD_SALVATOR_X:
-	case BOARD_SALVATOR_XS:
-	case BOARD_KRIEK:
-	case BOARD_STARTER_KIT:
-		/* Do nothing. */
-		break;
-	default:
-		board_type = BOARD_UNKNOWN;
-		break;
-	}
-	
-	(void)sprintf(msg, "BL2: Board is %s Rev%d.%d\n",
-		GET_BOARD_NAME(board_type), GET_BOARD_MAJOR(board_rev),
-		GET_BOARD_MINOR(board_rev));
+	board_id_init();
+
+	(void)sprintf(msg, "BL2: Board %s Rev%d.%d\n",
+			get_board_name(),
+			get_board_rev_major(),
+			get_board_rev_minor());
 	NOTICE("%s", msg);
 
 #if RCAR_LSI != RCAR_AUTO
@@ -830,8 +816,9 @@ void bl2_init_generic_timer(void)
 				12500000U,	/* MD14/MD13 : 0b10 */
 				16666600U};	/* MD14/MD13 : 0b11 */
 	uint32_t reg_cntfid;
-	uint32_t board_type;
-	uint32_t board_rev;
+
+	/* board id initialization before bl2_early_platform_setup */
+	board_id_init();
 
 	modemr = mmio_read_32(RCAR_MODEMR);
 	modemr_pll = (modemr & MODEMR_BOOT_PLL_MASK);
@@ -841,10 +828,8 @@ void bl2_init_generic_timer(void)
 	reg = mmio_read_32(RCAR_PRR) & (RCAR_PRODUCT_MASK | RCAR_CUT_MASK);
 	switch (modemr_pll) {
 	case MD14_MD13_TYPE_0:
-		(void)get_board_type(&board_type, &board_rev);
-		if (BOARD_SALVATOR_XS == board_type) {
+		if (board_is(BOARD_SALVATOR_XS))
 			reg_cntfid = 8320000U;
-		}
 		break;
 	case MD14_MD13_TYPE_3:
 		if (RCAR_PRODUCT_H3_CUT10 == reg) {
@@ -862,5 +847,4 @@ void bl2_init_generic_timer(void)
 	mmio_setbits_32(RCAR_CNTC_BASE + (uintptr_t)CNTCR_OFF,
 		(uint32_t)CNTCR_EN);
 }
-
 

--- a/plat/renesas/rcar/drivers/board/board.c
+++ b/plat/renesas/rcar/drivers/board/board.c
@@ -27,83 +27,102 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include <stdint.h>
 #include <iic_dvfs.h>
 #include "board.h"
 
+static uint8_t board_id = BOARD_ID_UNKNOWN;
 
-/************************************************************************
- * Defines
- ************************************************************************/
-#ifndef BOARD_DEFAULT
-#define BOARD_DEFAULT		(BOARD_SALVATOR_X << BOARD_CODE_SHIFT)
-#endif
-
-#define SLAVE_ADDR_EEPROM	(0x50U)
-#define	REG_ADDR_BOARD_ID	(0x70U)
-
-#define BOARD_CODE_MASK		(0xF8U)
-#define BOARD_REV_MASK		(0x07U)
-#define BOARD_CODE_SHIFT	(3U)
-
-#define BOARD_ID_UNKNOWN	(0xFFU)
-
-
-/************************************************************************
- * Global variables
- ************************************************************************/
-const char *g_board_tbl[] = {
-	[BOARD_SALVATOR_X]	= "Salvator-X",
-	[BOARD_SALVATOR_XS]	= "Salvator-XS",
-	[BOARD_KRIEK]		= "Kriek",
-	[BOARD_STARTER_KIT]	= "Starter Kit"
-};
-const char *g_board_unknown	= "unknown";
-
-
-int32_t get_board_type(uint32_t *type, uint32_t *rev)
+void board_id_init()
 {
-	int32_t ret = 0;
-	uint8_t read_rev;
-	static uint8_t g_board_id = BOARD_ID_UNKNOWN;
-	const uint8_t board_tbl[][8U] = {
-		[BOARD_SALVATOR_X]	= {0x10U, 0x11U, 0xFFU, 0xFFU,
-					   0xFFU, 0xFFU, 0xFFU, 0xFFU},
-		[BOARD_KRIEK]		= {0x10U, 0xFFU, 0xFFU, 0xFFU,
-					   0xFFU, 0xFFU, 0xFFU, 0xFFU},
-		[BOARD_STARTER_KIT]	= {0x10U, 0xFFU, 0xFFU, 0xFFU,
-					   0xFFU, 0xFFU, 0xFFU, 0xFFU},
-		[BOARD_SALVATOR_XS]	= {0x10U, 0xFFU, 0xFFU, 0xFFU,
-					   0xFFU, 0xFFU, 0xFFU, 0xFFU},
-	};
+	uint8_t id = BOARD_ID_UNKNOWN;
+	int ret;
 
-	if (BOARD_ID_UNKNOWN == g_board_id) {
-#if PMIC_ON_BOARD
-		/* Board ID detection from EEPROM */
-		ret = rcar_iic_dvfs_recieve(SLAVE_ADDR_EEPROM,
-			REG_ADDR_BOARD_ID, &g_board_id);
-		if (0 != ret) {
-			g_board_id = BOARD_ID_UNKNOWN;
-		} else if (BOARD_ID_UNKNOWN == g_board_id) {
-			/* Can't recognize the board */
-			g_board_id = BOARD_DEFAULT;
-		} else {
-			/* none */
-		}
-#else
-		g_board_id = BOARD_DEFAULT;
+	/* board detection and validation had been done already */
+	if (board_id != BOARD_ID_UNKNOWN)
+		return;
+
+#if PMIC_ON_BOARD && !defined(BOARD_ID)
+	/* Board ID detection from EEPROM */
+	ret = rcar_iic_dvfs_recieve(PMIC_EEPROM_SLAVE_ADDR,
+				PMIC_EEPROM_BOARD_ID_REG_ADDR, &id);
+	if (ret != 0)
+		id = BOARD_ID_UNKNOWN;
 #endif
+
+#ifdef BOARD_ID
+	id = BOARD_ID;
+#endif
+	if (id == BOARD_ID_UNKNOWN)
+		id = BOARD_ID_DEFAULT;
+
+	switch (id >> BOARD_ID_NAME_SHIFT) {
+	case BOARD_SALVATOR_X:
+	case BOARD_KRIEK:
+	case BOARD_STARTER_KIT:
+	case BOARD_SALVATOR_XS:
+		break;
+	default:
+		id = BOARD_ID_DEFAULT;
+		break;
 	}
 
-	*type = ((uint32_t)g_board_id & BOARD_CODE_MASK) >> BOARD_CODE_SHIFT;
-	if (*type < (sizeof(board_tbl) / sizeof(board_tbl[0]))) {
-		read_rev = (uint8_t)(g_board_id & BOARD_REV_MASK);
-		*rev = board_tbl[*type][read_rev];
-	} else {
-		/* If there is no revision information, set Rev0.0. */
-		*rev = 0x00U;
-	}
+	board_id = id;
+}
 
-	return ret;
+static const char *board_name[] = {
+	[BOARD_SALVATOR_X]	= "Salvator-X",
+	[BOARD_KRIEK]		= "Kriek",
+	[BOARD_STARTER_KIT]	= "Starter Kit",
+	[BOARD_SALVATOR_XS]	= "Salvator-XS"
+};
+
+int32_t get_board_id()
+{
+	return board_id;
+}
+
+const char *get_board_name()
+{
+	return board_name[board_id];
+}
+
+/* board rev ID is not linearly mapped to revision string
+ *   0 : rev1.0
+ *   1 : rev1.1
+ *   ...
+ *
+ * rev ID translation is done via lookup table as below
+ *
+ *  7      4 3      0
+ * +--------+--------+
+ * | major  | minor  |
+ * +--------+--------+
+ */
+static const uint8_t board_rev[] = {
+	/* 0     1      2      3 */
+	0x10U, 0x11U, 0xFFU, 0xFFU,
+	/* 4     5      6      7 */
+	0xFFU, 0xFFU, 0xFFU, 0xFFU
+};
+
+int32_t get_board_rev()
+{
+	int32_t rev = board_id & BOARD_ID_REV_MASK;
+
+	return board_rev[rev];
+}
+
+int32_t get_board_rev_major()
+{
+	int32_t rev = board_id & BOARD_ID_REV_MASK;
+
+	return board_rev[rev] >> 4;
+}
+
+int32_t get_board_rev_minor()
+{
+	int32_t rev = board_id & BOARD_ID_REV_MASK;
+
+	return board_rev[rev] & 0xFU;
 }

--- a/plat/renesas/rcar/drivers/board/board.h
+++ b/plat/renesas/rcar/drivers/board/board.h
@@ -27,38 +27,43 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#ifndef _RCAR_BOARD_H_
+#define _RCAR_BOARD_H_
 
-#ifndef BOARD_H_
-#define BOARD_H_
+/* board ID register in the EEPROM (e.g. BR24T01FVM-W)
+ *
+ *   7        3   2    0
+ * +------------+--------+
+ * |  name ID   | rev ID |
+ * +------------+--------+
+ */
+#define PMIC_EEPROM_SLAVE_ADDR		(0x50U)
+#define	PMIC_EEPROM_BOARD_ID_REG_ADDR	(0x70U)
 
+/* board ID bit fields definition */
+#define BOARD_ID_NAME_MASK	(0xF8U)
+#define BOARD_ID_NAME_SHIFT 	(3U)
+#define BOARD_ID_REV_MASK	(0x07U)
 
-/************************************************************************
- * Board type
- ************************************************************************/
-#define BOARD_SALVATOR_X		(0x00U)
-#define BOARD_SALVATOR_XS		(0x04U)
-#define BOARD_KRIEK			(0x01U)
-#define BOARD_STARTER_KIT		(0x02U)
+/* board name ID */
+#define BOARD_SALVATOR_X	(0x00U)
+#define BOARD_KRIEK		(0x01U)
+#define BOARD_STARTER_KIT	(0x02U) /* i.e. ULCB */
+#define BOARD_SALVATOR_XS	(0x04U)
+#define BOARD_UNKNOWN		(0x1FU)
 
-#define BOARD_UNKNOWN			(0x1FU)
+/* If board ID is not specified during compiling, or board detection fails,
+ * then fallback to Salvator-X Rev1.0  */
+#define BOARD_ID_DEFAULT 	(BOARD_SALVATOR_X << BOARD_ID_NAME_SHIFT)
+#define BOARD_ID_UNKNOWN	(0xFFU)
 
-/************************************************************************
- * Board name
- ************************************************************************/
-extern const char *g_board_tbl[];
-extern const char *g_board_unknown;
+#define board_is(board) ((get_board_id() >> BOARD_ID_NAME_SHIFT) == board)
 
-/************************************************************************
- * Revisions are expressed in 8 bits.
- *  The upper 4 bits are major version.
- *  The lower 4 bits are minor version.
- ************************************************************************/
-#define GET_BOARD_MAJOR(a)	((uint32_t)(a) >> 4U)
-#define GET_BOARD_MINOR(a)	((uint32_t)(a) & 0xFU)
+void board_id_init();
+int32_t get_board_id();
+const char *get_board_name();
+int32_t get_board_name_id();
+int32_t get_board_rev_major();
+int32_t get_board_rev_minor();
 
-#define GET_BOARD_NAME(a)	((BOARD_UNKNOWN != (a)) ?\
-					g_board_tbl[(a)] : g_board_unknown)
-
-int32_t get_board_type(uint32_t *type, uint32_t *rev);
-
-#endif /* BOARD_H_ */
+#endif /* _RCAR_BOARD_H_ */

--- a/plat/renesas/rcar/platform.mk
+++ b/plat/renesas/rcar/platform.mk
@@ -237,8 +237,8 @@ ifndef RCAR_GEN3_ULCB
 RCAR_GEN3_ULCB := 0
 endif
 ifeq (${RCAR_GEN3_ULCB},1)
- BOARD_DEFAULT := 0x10
- $(eval $(call add_define,BOARD_DEFAULT))
+ BOARD_ID := 0x10
+ $(eval $(call add_define,BOARD_ID))
 endif
 $(eval $(call add_define,RCAR_GEN3_ULCB))
 


### PR DESCRIPTION
Detection rule:
 - prefer board ID specified during compiling
 - board ID read from PMIC EEPROM if it is valid
 - fallback to Salvator-X Rev1.0