### PR TITLE
Remove CPG_CPGWPR redefinition

### DIFF
--- a/plat/renesas/rcar/drivers/emmc/emmc_init.c
+++ b/plat/renesas/rcar/drivers/emmc/emmc_init.c
@@ -13,6 +13,7 @@
 /* ************************ HEADER (INCLUDE) SECTION *********************** */
 #include <stddef.h>
 #include <mmio.h>
+#include "bl2_cpg_register.h"
 #include "emmc_config.h"
 #include "emmc_hal.h"
 #include "emmc_std.h"

--- a/plat/renesas/rcar/include/emmc_registers.h
+++ b/plat/renesas/rcar/include/emmc_registers.h
@@ -73,8 +73,6 @@
 #define	CPG_SD2CKCR		(CPG_BASE+0x0268U)	/* SDHI2 clock frequency control register */
 #define CPG_SD3CKCR		(CPG_BASE+0x026CU)	/* SDHI3 clock frequency control register */
 
-#define	CPG_CPGWPR		(CPG_BASE+0x0900U)	/* CPG Write Protect Register */
-
 #if USE_MMC_CH == MMC_CH0
 #define	CPG_SDxCKCR		(CPG_SD2CKCR)		/* SDHI2/MMC0 */
 #else  /* USE_MMC_CH == MMC_CH0 */


### PR DESCRIPTION
emmc_registers.h contains redefinition of
CPG_CPGWPR from bl2_cpg_register.h